### PR TITLE
Dashboard friends

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,5 @@
+class FriendshipsController < ApplicationController
+  def create
+    redirect_to dashboard_path
+  end
+end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,5 +1,8 @@
 class FriendshipsController < ApplicationController
   def create
+    @friend = User.find_by(username: params[:email])
+    Friendship.create(user_id: current_user.id, friend_id: @friend.id)
+    flash[:success] = "You have added #{@friend.username} as a friend."
     redirect_to dashboard_path
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,8 +1,13 @@
 class FriendshipsController < ApplicationController
   def create
-    @friend = User.find_by(username: params[:email])
-    Friendship.create(user_id: current_user.id, friend_id: @friend.id)
-    flash[:success] = "You have added #{@friend.username} as a friend."
+    friend_email = params[:email]
+    @friend = User.find_by(username: friend_email)
+    unless @friend.nil?
+      Friendship.create(user_id: current_user.id, friend_id: @friend.id)
+      flash[:success] = "You have added #{@friend.username} as a friend."
+    else
+      flash[:error] = "User with email #{friend_email} does not exist."
+    end
     redirect_to dashboard_path
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -3,8 +3,8 @@ class FriendshipsController < ApplicationController
     friend_email = params[:email]
     @friend = User.find_by(username: friend_email)
     if @friend
-      Friendship.create(user_id: current_user.id, friend_id: @friend.id)
-      Friendship.create(user_id: @friend.id, friend_id: current_user.id)
+      # Friendship.create(user_id: current_user.id, friend_id: @friend.id)
+      Friendship.create_reciprocal_friendship(current_user.id, @friend.id)
       flash[:success] = "You have added #{@friend.username} as a friend."
     else
       flash[:error] = "User with email #{friend_email} does not exist."
@@ -12,3 +12,22 @@ class FriendshipsController < ApplicationController
     redirect_to dashboard_path
   end
 end
+
+
+
+# def create
+#   #is this bulk addition or individual addition?
+#   if params.include?(:friend_id) #individual e.g. "Add friend" link
+#     @new_friendships = Friendship.create_reciprocal_for_ids(current_user_id, params[:friend_id])
+#   else
+#     params[:user][:friend_ids].each do |f_id|
+#       @new_friendships = Friendship.create_reciprocal_for_ids(current_user_id, f_id)
+#     end
+#   end
+#   redirect_to users_path
+# end
+#
+# def destroy
+#   Friendship.destroy_reciprocal_for_ids(current_user_id, params[:friend_id])
+#   redirect_to(request.referer)
+# end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -2,8 +2,9 @@ class FriendshipsController < ApplicationController
   def create
     friend_email = params[:email]
     @friend = User.find_by(username: friend_email)
-    unless @friend.nil?
+    if @friend
       Friendship.create(user_id: current_user.id, friend_id: @friend.id)
+      Friendship.create(user_id: @friend.id, friend_id: current_user.id)
       flash[:success] = "You have added #{@friend.username} as a friend."
     else
       flash[:error] = "User with email #{friend_email} does not exist."

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,4 +1,18 @@
 class Friendship < ApplicationRecord
   belongs_to :user
   belongs_to :friend, class_name: 'User'
+
+  def self.create_reciprocal_friendship(user_id, friend_id)
+    Friendship.create(user_id: user_id, friend_id: friend_id)
+    Friendship.create(user_id: friend_id, friend_id: user_id)
+  end
 end
+
+
+
+
+# def self.create_reciprocal_for_ids(user_id, friend_id)
+#   user_friendship = Friendship.create(user_id: user_id, friend_id: friend_id)
+#   friend_friendship = Friendship.create(user_id: friend_id, friend_id: user_id)
+#   [user_friendship, friend_friendship]
+# end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -9,7 +9,15 @@
     <%= email_field_tag :email  %>
     <%= submit_tag "Add Friend" %>
   <% end %>
-  <p>You currently have no friends.</p>
+  <% unless current_user.friends.empty? %>
+    <% current_user.friends.each do |friend| %>
+      <ul class="friends-list">
+        <li><%= friend.username %></li>
+      </ul>
+    <% end %>
+  <% else %>
+    <p>You currently have no friends.</p>
+  <% end %>
 </section>
 
 <section class="viewing-parties">

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -3,6 +3,13 @@
 <%= button_to "Discover Movies", discover_path, method: :get %>
 
 <section class="friends">
+  <center>
+  <%= form_tag friendships_path, method: :post do %>
+    <%= label_tag :friend_email, "Friend's Email" %>
+    <%= email_field_tag :email  %>
+    <%= submit_tag "Add Friend" %>
+  <% end %>
+</center>
   <%# <%=# button_to "Add Friend", discover_path, method: :get %> %>
   <p>You currently have no friends.</p>
 </section>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -3,17 +3,16 @@
 <%= button_to "Discover Movies", discover_path, method: :get %>
 
 <section class="friends">
-  <center>
+  <h2>Friends</h2>
   <%= form_tag friendships_path, method: :post do %>
     <%= label_tag :friend_email, "Friend's Email" %>
     <%= email_field_tag :email  %>
     <%= submit_tag "Add Friend" %>
   <% end %>
-</center>
-  <%# <%=# button_to "Add Friend", discover_path, method: :get %> %>
   <p>You currently have no friends.</p>
 </section>
 
 <section class="viewing-parties">
+  <h2>Viewing Parties</h2>
   <p>You have no viewing parties coming up.</p>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,10 @@
 
   <body>
     <main>
+      <% flash.each do |type, message| %>
+        <p><%= message %></p>
+      <% end %>
+      
       <%= yield %>
     </main>
     <footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   get "/auth/:provider/callback", to: "sessions#create"
   get "/dashboard", to: "dashboard#show"
   get "/discover", to: "discover#index"
+  post "/friendships", to: "friendships#create"
 end

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe 'dashboard show page' do
     before :each do
       visit root_path
       click_on "Login"
+      existing_user_attributes = {}
+      @existing_user = User.create!()
     end
 
     it "the dashboard has a 'Discover Movies' button that redirects me to a discover page" do
@@ -14,6 +16,7 @@ RSpec.describe 'dashboard show page' do
     it "the dashboard has a 'Friends' section with a 'no friends' message if I haven't added any friends" do
       expect(page).to have_css(".friends") # repetetive but including this until the rest of the section is built out
       within(".friends") do
+        # alternative field name: friend_search_field ?
         expect(page).to have_field("#friend-email")
         expect(page).to have_button("Add Friend")
         expect(page).to have_content("You currently have no friends.")
@@ -23,10 +26,11 @@ RSpec.describe 'dashboard show page' do
     it "when I enter a friend's email associated with another existing user, they are added
       to my friends list, which displays their email" do
       # confirm whether user stories specify *what* details should be displayed for each friend
+
+      # create a stub for existing user??
       existing_user = "ruthie@gmail.com"
       within(".friends") do
         expect(page).to_not have_content(existing_user)
-        # alternative field name: friend_search_field ?
         fill_in :friend_email, with: existing_user
         click_button "Add Friend"
       end

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -3,8 +3,6 @@ RSpec.describe 'dashboard show page' do
     before :each do
       visit root_path
       click_on "Login"
-      existing_user_attributes = {}
-      @existing_user = User.create!()
     end
 
     it "the dashboard has a 'Discover Movies' button that redirects me to a discover page" do
@@ -24,21 +22,20 @@ RSpec.describe 'dashboard show page' do
     end
 
     it "when I enter a friend's email associated with another existing user, they are added
-      to my friends list, which displays their email" do
+      to my friends list, which displays their email (referenced as username)" do
       # confirm whether user stories specify *what* details should be displayed for each friend
+      existing_user = User.create!(user_id: 123, username: "ruthie@gmail.com", token: "123ruthie", refresh_token: "ruthie123")
 
-      # create a stub for existing user??
-      existing_user = "ruthie@gmail.com"
       within(".friends") do
-        expect(page).to_not have_content(existing_user)
-        fill_in :friend_email, with: existing_user
+        expect(page).to_not have_content(existing_user.username)
+        fill_in :friend_email, with: existing_user.username
         click_button "Add Friend"
       end
 
       expect(current_path).to eq(dashboard_path)
       # if we use a partial to have the flash message appear within the friends section instead
       # of at the top of the page, this expectation can be moved into the within(".friends") block below
-      expect(page).to have_content("You have added #{existing_user} as a friend.")
+      expect(page).to have_content("You have added #{existing_user.username} as a friend.")
 
       within(".friends") do
         expect(page).to have_content(friend_email)

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe 'dashboard show page' do
       expect(page).to have_content("You have added #{existing_user.username} as a friend.")
 
       within(".friends") do
-        expect(page).to have_content(friend_email)
+        expect(page).to have_content(existing_user.username)
+        expect(page).to_not have_content("You currently have no friends.")
       end
     end
 

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -11,13 +11,46 @@ RSpec.describe 'dashboard show page' do
       expect(current_path).to eq(discover_path)
     end
 
-    it "the dashboard has a 'Friends' section" do
+    it "the dashboard has a 'Friends' section with a 'no friends' message if I haven't added any friends" do
       expect(page).to have_css(".friends") # repetetive but including this until the rest of the section is built out
       within(".friends") do
-        # expect(page).to have_field("#friend-email")
-        # expect(page).to have_button("Add Friend")
+        expect(page).to have_field("#friend-email")
+        expect(page).to have_button("Add Friend")
         expect(page).to have_content("You currently have no friends.")
       end
+    end
+
+    it "when I enter a friend's email associated with another existing user, they are added
+      to my friends list, which displays their email" do
+      # confirm whether user stories specify *what* details should be displayed for each friend
+      existing_user = "ruthie@gmail.com"
+      within(".friends") do
+        expect(page).to_not have_content(existing_user)
+        # alternative field name: friend_search_field ?
+        fill_in :friend_email, with: existing_user
+        click_button "Add Friend"
+      end
+
+      expect(current_path).to eq(dashboard_path)
+      # if we use a partial to have the flash message appear within the friends section instead
+      # of at the top of the page, this expectation can be moved into the within(".friends") block below
+      expect(page).to have_content("You have added #{existing_user} as a friend.")
+
+      within(".friends") do
+        expect(page).to have_content(friend_email)
+      end
+    end
+
+    it "when I enter an email not associated with an existing user, I see an error message indicating
+      that the user does not exist" do
+      nonexistant_user = "noodle@gmail.com"
+      within(".friends") do
+        fill_in :friend_email, with: nonexistant_user
+        click_button "Add Friend"
+      end
+
+      expect(current_path).to eq(dashboard_path)
+      expect(page).to have_content("#{nonexistant_user} does not exist.")
     end
 
     it "the dashboard has a 'Viewing Parties' section" do

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe 'dashboard show page' do
     end
 
     it "the dashboard has a 'Viewing Parties' section" do
-      expect(page).to have_css(".viewing-parties") # repetetive but including this until the rest of the section is built out
       within(".viewing-parties") do
         expect(page).to have_content("You have no viewing parties coming up.")
       end

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'dashboard show page' do
 
       within(".friends") do
         expect(page).to_not have_content(existing_user.username)
-        fill_in :friend_email, with: existing_user.username
+        fill_in :email, with: existing_user.username
         click_button "Add Friend"
       end
 

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -45,12 +45,12 @@ RSpec.describe 'dashboard show page' do
       that the user does not exist" do
       nonexistant_user = "noodle@gmail.com"
       within(".friends") do
-        fill_in :friend_email, with: nonexistant_user
+        fill_in :email, with: nonexistant_user
         click_button "Add Friend"
       end
 
       expect(current_path).to eq(dashboard_path)
-      expect(page).to have_content("#{nonexistant_user} does not exist.")
+      expect(page).to have_content("User with email #{nonexistant_user} does not exist.")
     end
 
     it "the dashboard has a 'Viewing Parties' section" do

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe 'dashboard show page' do
     end
 
     it "the dashboard has a 'Friends' section with a 'no friends' message if I haven't added any friends" do
-      expect(page).to have_css(".friends") # repetetive but including this until the rest of the section is built out
       within(".friends") do
-        # alternative field name: friend_search_field ?
         expect(page).to have_selector("#email")
         expect(page).to have_button("Add Friend")
         expect(page).to have_content("You currently have no friends.")

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'dashboard show page' do
       expect(page).to have_css(".friends") # repetetive but including this until the rest of the section is built out
       within(".friends") do
         # alternative field name: friend_search_field ?
-        expect(page).to have_field("#friend-email")
+        expect(page).to have_selector("#email")
         expect(page).to have_button("Add Friend")
         expect(page).to have_content("You currently have no friends.")
       end


### PR DESCRIPTION
• Adds functionality for a logged in user to be able to add another existing user to their friends list via manual email entry process
• If the email submitted is not associated with an existing user, a flash message is shown indicating the addition of a new friend was not successful

(keeping comments in the `FriendshipsController` and `Friendship` files for reference if/when we need to delete friendships - may not be necessary)