### PR TITLE
Discover & Movie Pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,11 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - './*'
+  UseCache: false
+  DefaultFormatter: progress
+  DisplayStyleGuide: true
+  DisplayCopNames: false
+  TargetRubyVersion: 2.5
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.2'
 gem 'bootsnap'
 gem 'jbuilder', '~> 2.5'
+gem 'json'
+
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,6 +284,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   figaro
   jbuilder (~> 2.5)
+  json
   launchy
   listen (>= 3.0.5, < 3.2)
   omniauth-google-oauth2

--- a/app/controllers/discover_controller.rb
+++ b/app/controllers/discover_controller.rb
@@ -1,3 +1,4 @@
 class DiscoverController < ApplicationController
-  def index; end
+  def index
+  end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,3 @@
+class MoviesController < ApplicationController
+  def index; end
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,30 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    # Refactor this disaster into a MovieDB Poro?
+    conn = Faraday.new(url: 'https://api.themoviedb.org', headers: { 'Accept': 'application/json' })
+
+    page1 = conn.get('/3/movie/top_rated') do |req|
+      req.params['api_key'] = ENV["MOVIE_DB_API_KEY_V3"]
+      req.params['language'] = 'en-US'
+      req.params['page'] = '1'
+    end
+
+    page2 = conn.get('/3/movie/top_rated') do |req|
+      req.params['api_key'] = ENV["MOVIE_DB_API_KEY_V3"]
+      req.params['language'] = 'en-US'
+      req.params['page'] = '2'
+    end
+
+    json1 = JSON.parse(page1.body, symbolize_names: true)
+    json2 = JSON.parse(page2.body, symbolize_names: true)
+
+    @movies_pg1 = json1[:results]
+    @movies_pg2 = json2[:results]
+
+    until json2[:results].count == 0
+      json1[:results] << json2[:results].shift
+    end
+
+    @movies = json1[:results]
+  end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -14,7 +14,7 @@ class MoviesController < ApplicationController
       req.params['language'] = 'en-US'
       req.params['page'] = '2'
     end
-
+    
     json1 = JSON.parse(page1.body, symbolize_names: true)
     json2 = JSON.parse(page2.body, symbolize_names: true)
 

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,8 +1,6 @@
 <%= button_to "Discover Movies", discover_path, method: :get %>
 
 <section class="friends">
-  <%# <%=# button_to "Add Friend", discover_path, method: :get %>
-  <p>You currently have no friends.</p>
   <h2>Friends</h2>
   <%= form_tag friendships_path, method: :post do %>
     <%= label_tag :friend_email, "Friend's Email" %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,5 +1,3 @@
-<h3>Welcome, <%= @user.username %></h3>
-
 <%= button_to "Discover Movies", discover_path, method: :get %>
 
 <section class="friends">

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,7 +1,7 @@
 <%= button_to "Discover Movies", discover_path, method: :get %>
 
 <section class="friends">
-  <%# <%=# button_to "Add Friend", discover_path, method: :get %> %>
+  <%# <%=# button_to "Add Friend", discover_path, method: :get %> 
   <p>You currently have no friends.</p>
 </section>
 

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -1,1 +1,2 @@
-<h1>Discover Movies</h1>
+<!-- discover/index.html.erb -->
+<%= button_to "Find Top Rated Movies", movies_path, method: :get %>

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -1,2 +1,7 @@
 <!-- discover/index.html.erb -->
 <%= button_to "Find Top Rated Movies", movies_path, method: :get %>
+
+<%= form_tag movies_path, method: :get do %>
+  <%= text_field_tag :movie_keywords %>
+  <%= submit_tag "Find Movies" %>
+<% end %>

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -1,1 +1,1 @@
-<h1>DISCOVER MOVIES INDEX PAGE</h1>
+<h1>Discover Movies</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,11 @@
   </head>
 
   <body>
+    <header>
+      <% if current_user %>
+        <h3>Welcome, <%= current_user.username %></h3>
+      <% end %>
+    </header>
     <main>
       <%= yield %>
     </main>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,1 @@
-<!-- discover/index.html.erb -->
 <%= render '/partials/movie_controls' %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,1 +1,9 @@
 <%= render '/partials/movie_controls' %>
+<section class="top40">
+<!-- top 40 rated movies from API here -->
+  <% @movies.each do |movie| %>
+    <div class="movie">
+      <h4><%= link_to movie[:title], "/movies?id=#{movie[:id]}", class: "movie-title" %> / <%= movie[:vote_average] %></h4>
+    </div>
+  <% end %>
+</section>

--- a/app/views/partials/_movie_controls.html.erb
+++ b/app/views/partials/_movie_controls.html.erb
@@ -1,0 +1,6 @@
+<%= button_to "Find Top Rated Movies", movies_path, method: :get %>
+
+<%= form_tag movies_path, method: :get do %>
+  <%= text_field_tag :movie_keywords %>
+  <%= submit_tag "Find Movies" %>
+<% end %>

--- a/app/views/partials/_movie_controls.html.erb
+++ b/app/views/partials/_movie_controls.html.erb
@@ -1,4 +1,4 @@
-<%= button_to "Find Top Rated Movies", movies_path, method: :get %>
+<%= button_to "Find Top Rated Movies", "/movies", method: :get %>
 
 <%= form_tag movies_path, method: :get do %>
   <%= text_field_tag :movie_keywords %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   get "/auth/:provider/callback", to: "sessions#create"
   get "/dashboard", to: "dashboard#show"
   get "/discover", to: "discover#index"
+  get "/movies", to: "movies#index"
 end

--- a/spec/features/discover/index_spec.rb
+++ b/spec/features/discover/index_spec.rb
@@ -4,14 +4,15 @@ RSpec.describe 'As an authenticated user' do
     click_on "Login"
   end
 
-  it 'I should see a button to discover top-rated movies' do
-    #
+  it 'I should see a button to discover top-rated movies; when I click on it, I\'m taken to the Movies page' do
+    
     visit discover_path
-    expect(page).to have_button("Find Top Rated Movies")
+    click_on "Find Top Rated Movies"
+    expect(current_path).to eq(movies_path)
   end
 
   it 'I should also see a text field to enter a keyword(s) in the movie title and a "Find Movies" button' do
-    #
+
     visit discover_path
     expect(page).to have_selector("#movie_keywords")
     expect(page).to have_button("Find Movies")

--- a/spec/features/discover/index_spec.rb
+++ b/spec/features/discover/index_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'As an authenticated user' do
+  before :each do
+    visit root_path
+    click_on "Login"
+  end
+
+  it 'I should see a button to discover top-rated movies' do
+    #
+    visit discover_path
+    expect(page).to have_button("Find Top Rated Movies")
+  end
+
+  it 'I should also see a text field to enter a keyword(s) in the movie title and a "Find Movies" button' do
+    #
+    visit discover_path
+    expect(page).to have_selector("#movie_keywords")
+    expect(page).to have_button("Find Movies")
+  end
+end

--- a/spec/features/movies/index_spec.rb
+++ b/spec/features/movies/index_spec.rb
@@ -1,0 +1,21 @@
+# movies/index_spec.rb
+RSpec.describe 'As an authenticated user' do
+  before :each do
+    visit root_path
+    click_on "Login"
+  end
+
+  it 'When I visit the movies page, I should see the 40 results from my search, I should also see the "Find Top Rated Movies" button and the Find Movies form at the top of the page.' do
+
+    visit discover_path
+    click_on "Find Top Rated Movies"
+    expect(current_path).to eq(movies_path)
+
+    expect(page).to have_selector("#movie_keywords")
+    expect(page).to have_button("Find Movies")
+
+    within(".top40") do
+      expect(page).to have_selector(".movie-title", count: 40)
+    end
+  end
+end


### PR DESCRIPTION
- Discover page has button to 'Find Top Rated Movies' and input search field for movie keywords.
- 'Find Top Rated Movies' links to GET MoviesController#index, where there is a Faraday connection to the Movie DB API to get 2 pages worth of top rated movies. _This will be refactored in a future PR, probably using a PORO for the Movie DB API work_
- Movies#index view shows a list of the 40 top rated movies along with their vote_average score. 
- Each movie title is a link (which is not routed yet) - will go to Movies Detail Page ([issue #10](https://github.com/rrabinovitch/viewing_party/issues/10))

- All tests pass.